### PR TITLE
2017年10月5日提交

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 仿 支付宝的指纹解锁,可输入密码验证
 
 调用方法：FingerPrintVerify *verify = [[FingerPrintVerify alloc] init];
-         [verify verifyFingerprint];
+         [verify verifyFingerprintWithSuccessHandler:^(void){
+	     //放置指纹验证成功后的代码，比如说确认支付，打开应用等
+	 }];
 
 ![image](https://github.com/shaw2014/Fingerprint/blob/master/images/image1.png)
 ![image](https://github.com/shaw2014/Fingerprint/blob/master/images/image2.png)

--- a/obj/FingerPrintVerify.h
+++ b/obj/FingerPrintVerify.h
@@ -11,6 +11,6 @@
 @interface FingerPrintVerify : NSObject
 
 //指纹验证
--(void)verifyFingerprint;
+-(void)verifyFingerprintWithSuccessHandler:(void (^)(void))handler;
 
 @end

--- a/obj/FingerPrintVerify.m
+++ b/obj/FingerPrintVerify.m
@@ -15,7 +15,7 @@
 @implementation FingerPrintVerify
 
 //指纹验证
--(void)verifyFingerprint
+-(void)verifyFingerprintWithSuccessHandler:(void (^)(void))handler
 {
     TouchInstance *instance = [TouchInstance instance];
     if([instance canEvaluatePolicy])
@@ -71,6 +71,8 @@
                     if(success)
                     {
                         result = YES;
+			//执行Handler的代码块
+                        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),handler);
                     }
                 }
                 


### PR DESCRIPTION
2017年10月5日在上一个版本中我只有把代码中放到verifyFingerprint中的result=YES里面才能执行验证成功后的代码，我觉得这样耦合度太高，用户应该可以在自己的代码里直接写验证成功后的代码，开始我想用@selector()来写，但是后来没有成功，后来想到用代码块也可以，而且调用也成功了，所以把代码push上来